### PR TITLE
fix: Exception when data protection key stored is incorrect

### DIFF
--- a/Ticky.Web/Components/Pages/BoardView.razor
+++ b/Ticky.Web/Components/Pages/BoardView.razor
@@ -1,4 +1,5 @@
 @page "/boards/{Id:int}/{CardId:int?}"
+@using System.Security.Cryptography
 @inject NavigationManager _navigationManager
 @inject IDbContextFactory<DataContext> _dbContextFactory
 @inject CardNumberingService _cardNumberingService
@@ -237,12 +238,19 @@
     {
         if (!firstRender)
             return;
-        
+
         objRef = DotNetObjectReference.Create(this);
         _initialCardId = CardId;
 
-        var boardPreferences = await _protectedLocalStorage.GetAsync<BoardPreferencesModel>(Constants.StorageKeys.BoardPreferences);
-        _preferences = (boardPreferences.Success ? boardPreferences.Value : new()) ?? new();
+        try
+        {
+            var boardPreferences = await _protectedLocalStorage.GetAsync<BoardPreferencesModel>(Constants.StorageKeys.BoardPreferences);
+            _preferences = (boardPreferences.Success ? boardPreferences.Value : new()) ?? new();
+        }
+        catch(CryptographicException)
+        {
+            _preferences = new();
+        }
 
         await HandleUpdate();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when loading board preferences to prevent issues if stored data cannot be decrypted. If an error occurs, preferences will reset instead of causing the page to fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->