### PR TITLE
feat: Option to set start date for repeat cards, meaning when next date should be calculated from

### DIFF
--- a/Ticky.Base/Models/RepeatCardModel.cs
+++ b/Ticky.Base/Models/RepeatCardModel.cs
@@ -32,6 +32,11 @@ public class RepeatCardModel
     [Range(1, 999)]
     public int? Number { get; set; }
 
+    [Display(Name = "Start from date")]
+    [Required(AllowEmptyStrings = false)]
+    [DataType(DataType.Date)]
+    public DateOnly StartDate { get; set; } = DateOnly.FromDateTime(DateTime.Now);
+
     [Display(Name = "Time of day for the repeat to occur")]
     [Required(AllowEmptyStrings = false)]
     [RegularExpression(

--- a/Ticky.Web/Components/Dialogs/AddOrEditRepeatModal.razor
+++ b/Ticky.Web/Components/Dialogs/AddOrEditRepeatModal.razor
@@ -52,6 +52,12 @@
             }
 
             <div class="form-group">
+                <Name For="() => _repeatModel.StartDate" />
+                <InputDate @bind-Value="_repeatModel.StartDate" />
+                <ValidationMessage For="() => _repeatModel.StartDate" />
+            </div>
+
+            <div class="form-group">
                 <Name For="() => _repeatModel.Time" />
                 <TimeSelect @bind-Value="_repeatModel.Time" />
                 <ValidationMessage For="() => _repeatModel.Time" />
@@ -127,6 +133,7 @@
             _repeatModel = new()
                 {
                     Type = card.RepeatInfo.Type,
+                    StartDate = DateOnly.FromDateTime(card.RepeatInfo.LastRepeat),
                     Time = card.RepeatInfo.Time.ToString("HH:mm"),
                     Number = card.RepeatInfo.Number,
                     CardPlacement = card.RepeatInfo.CardPlacement,
@@ -157,11 +164,13 @@
             return;
 
         var time = DateTime.ParseExact(_repeatModel.Time, "HH:mm", null);
+        var timeOnly = TimeOnly.FromDateTime(time);
 
         card.RepeatInfo = new()
         {
             Type = _repeatModel.Type,
-            Time = TimeOnly.FromDateTime(time),
+            LastRepeat = _repeatModel.StartDate.ToDateTime(timeOnly),
+            Time = timeOnly,
             Number = _repeatModel.Number,
             Selected = _repeatModel.GetRelevantSelectedValue(),
             CardPlacement = _repeatModel.CardPlacement,

--- a/Ticky.Web/wwwroot/css/app.css
+++ b/Ticky.Web/wwwroot/css/app.css
@@ -380,6 +380,9 @@
   .\!h-32 {
     height: calc(var(--spacing) * 32) !important;
   }
+  .h-0 {
+    height: calc(var(--spacing) * 0);
+  }
   .h-0\.5 {
     height: calc(var(--spacing) * 0.5);
   }
@@ -446,6 +449,9 @@
   .w-2 {
     width: calc(var(--spacing) * 2);
   }
+  .w-4 {
+    width: calc(var(--spacing) * 4);
+  }
   .w-4\/5 {
     width: calc(4/5 * 100%);
   }
@@ -511,6 +517,9 @@
   }
   .grow {
     flex-grow: 1;
+  }
+  .border-collapse {
+    border-collapse: collapse;
   }
   .border-separate {
     border-collapse: separate;
@@ -739,6 +748,9 @@
   .bg-app-bg {
     background-color: var(--color-app-bg);
   }
+  .bg-backdrop {
+    background-color: var(--color-backdrop);
+  }
   .bg-backdrop\/0 {
     background-color: color-mix(in srgb, oklch(0.446 0.03 256.802) 0%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -826,6 +838,9 @@
   .\!p-0 {
     padding: calc(var(--spacing) * 0) !important;
   }
+  .p-0 {
+    padding: calc(var(--spacing) * 0);
+  }
   .p-0\.5 {
     padding: calc(var(--spacing) * 0.5);
   }
@@ -864,6 +879,9 @@
   }
   .px-12 {
     padding-inline: calc(var(--spacing) * 12);
+  }
+  .py-0 {
+    padding-block: calc(var(--spacing) * 0);
   }
   .py-0\.5 {
     padding-block: calc(var(--spacing) * 0.5);
@@ -1042,6 +1060,9 @@
   .capitalize {
     text-transform: capitalize;
   }
+  .underline {
+    text-decoration-line: underline;
+  }
   .opacity-0 {
     opacity: 0%;
   }
@@ -1072,6 +1093,10 @@
   .shadow-sm {
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .outline {
+    outline-style: var(--tw-outline-style);
+    outline-width: 1px;
   }
   .outline-0 {
     outline-style: var(--tw-outline-style);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to set a start date when configuring repeat options for cards.
  * The repeat card modal now includes a field for selecting the start date.

* **Style**
  * Introduced new utility CSS classes for height, width, border, background, padding, text decoration, and outline to enhance layout and appearance options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->