### PR TITLE
feat: Used concurrency group for unstable release to cancel previous runs with many PRs

### DIFF
--- a/.github/workflows/docker-unstable.yml
+++ b/.github/workflows/docker-unstable.yml
@@ -12,7 +12,7 @@ on:
         default: "main"
 
 concurrency:
-  group: "docker-unstable"
+  group: docker-unstable-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow efficiency by ensuring that only the latest pipeline run is executed when multiple runs are triggered in quick succession.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->