### PR TITLE
fix: Overflowing text if no spaces present in card view

### DIFF
--- a/Ticky.Web/Components/Elements/CardView.razor
+++ b/Ticky.Web/Components/Elements/CardView.razor
@@ -1,4 +1,4 @@
-@inject IDbContextFactory<DataContext> _dbContextFactory
+﻿@inject IDbContextFactory<DataContext> _dbContextFactory
 
 <div data-blocked="@Card.Blocked.ToString()" class="task-card" @onclick="() => EditCardModal.Open(Card.Id, Members, Columns)">
     <div class="flex flex-row items-center justify-between gap-2">
@@ -17,7 +17,7 @@
             <i class="fa fa-ellipsis card-button pr-1"></i>
         </Dropdown>
     </div>
-    <label class="cursor-pointer text-xs">
+    <label class="cursor-pointer text-xs break-all">
         @Card.Name
     </label>
     <div class="flex flex-row items-center justify-between gap-3">

--- a/Ticky.Web/wwwroot/css/app.css
+++ b/Ticky.Web/wwwroot/css/app.css
@@ -673,6 +673,9 @@
   .overflow-auto {
     overflow: auto;
   }
+  .overflow-clip {
+    overflow: clip;
+  }
   .overflow-hidden {
     overflow: hidden;
   }
@@ -972,6 +975,12 @@
   .font-semibold {
     --tw-font-weight: var(--font-weight-semibold);
     font-weight: var(--font-weight-semibold);
+  }
+  .break-all {
+    word-break: break-all;
+  }
+  .overflow-ellipsis {
+    text-overflow: ellipsis;
   }
   .text-ellipsis {
     text-overflow: ellipsis;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new CSS utility classes for improved text and overflow handling, including options to clip overflowing content, break words anywhere, and display ellipsis for truncated text.
* **Style**
  * Updated card name labels to better handle long or unbroken text, preventing overflow and improving display consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->