### PR TITLE
fix: Tailwind ignore email templates

### DIFF
--- a/Ticky.Web/app.css
+++ b/Ticky.Web/app.css
@@ -1,4 +1,5 @@
 ﻿@import "tailwindcss";
+@config "./tailwind.config.js";
 
 @theme {
     --color-primary: oklch(0.595 0.2538 297);

--- a/Ticky.Web/tailwind.config.js
+++ b/Ticky.Web/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./**/*.{razor,cshtml,html}",
+    // Explicitly exclude email templates
+    "!./wwwroot/emails/**/*"
+  ]
+}

--- a/Ticky.Web/wwwroot/css/app.css
+++ b/Ticky.Web/wwwroot/css/app.css
@@ -288,30 +288,6 @@
   .z-20 {
     z-index: 20;
   }
-  .container {
-    width: 100%;
-    @media (width >= 20rem) {
-      max-width: 20rem;
-    }
-    @media (width >= 30rem) {
-      max-width: 30rem;
-    }
-    @media (width >= 40rem) {
-      max-width: 40rem;
-    }
-    @media (width >= 48rem) {
-      max-width: 48rem;
-    }
-    @media (width >= 64rem) {
-      max-width: 64rem;
-    }
-    @media (width >= 80rem) {
-      max-width: 80rem;
-    }
-    @media (width >= 96rem) {
-      max-width: 96rem;
-    }
-  }
   .m-5 {
     margin: calc(var(--spacing) * 5);
   }
@@ -404,9 +380,6 @@
   .\!h-32 {
     height: calc(var(--spacing) * 32) !important;
   }
-  .h-0 {
-    height: calc(var(--spacing) * 0);
-  }
   .h-0\.5 {
     height: calc(var(--spacing) * 0.5);
   }
@@ -473,9 +446,6 @@
   .w-2 {
     width: calc(var(--spacing) * 2);
   }
-  .w-4 {
-    width: calc(var(--spacing) * 4);
-  }
   .w-4\/5 {
     width: calc(4/5 * 100%);
   }
@@ -541,9 +511,6 @@
   }
   .grow {
     flex-grow: 1;
-  }
-  .border-collapse {
-    border-collapse: collapse;
   }
   .border-separate {
     border-collapse: separate;
@@ -772,9 +739,6 @@
   .bg-app-bg {
     background-color: var(--color-app-bg);
   }
-  .bg-backdrop {
-    background-color: var(--color-backdrop);
-  }
   .bg-backdrop\/0 {
     background-color: color-mix(in srgb, oklch(0.446 0.03 256.802) 0%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -862,9 +826,6 @@
   .\!p-0 {
     padding: calc(var(--spacing) * 0) !important;
   }
-  .p-0 {
-    padding: calc(var(--spacing) * 0);
-  }
   .p-0\.5 {
     padding: calc(var(--spacing) * 0.5);
   }
@@ -903,9 +864,6 @@
   }
   .px-12 {
     padding-inline: calc(var(--spacing) * 12);
-  }
-  .py-0 {
-    padding-block: calc(var(--spacing) * 0);
   }
   .py-0\.5 {
     padding-block: calc(var(--spacing) * 0.5);
@@ -1087,9 +1045,6 @@
   .capitalize {
     text-transform: capitalize;
   }
-  .underline {
-    text-decoration-line: underline;
-  }
   .opacity-0 {
     opacity: 0%;
   }
@@ -1120,10 +1075,6 @@
   .shadow-sm {
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-  }
-  .outline {
-    outline-style: var(--tw-outline-style);
-    outline-width: 1px;
   }
   .outline-0 {
     outline-style: var(--tw-outline-style);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enabled Tailwind CSS configuration for the web app to better manage style generation.
- Style
  - Cleaned up legacy CSS utilities and simplified global styles.
  - Removed outdated layout helpers, which may subtly adjust page widths, spacing, and text decoration in some views.
- Chores
  - Linked the app stylesheet to use the centralized Tailwind configuration.
  - Optimized CSS scanning to include app views while excluding email templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->