### PR TITLE
fix: Hide passwords in the user settings

### DIFF
--- a/Ticky.Web/Components/Pages/UserSettings.razor
+++ b/Ticky.Web/Components/Pages/UserSettings.razor
@@ -150,20 +150,20 @@
                     {
                         <div class="form-group">
                             <Name For="() => _credentialsModel.OldPassword" />
-                            <InputText type="password" autocomplete="current-password" autocapitalize="off" class="form-control" @bind-Value="_credentialsModel.OldPassword"/>
+                            <InputText type="password" autocomplete="current-password" autocapitalize="off" spellcheck="false" class="form-control" @bind-Value="_credentialsModel.OldPassword"/>
                             <ValidationMessage For="() => _credentialsModel.OldPassword" />
                         </div>
                     }
 
                     <div class="form-group">
                         <Name For="() => _credentialsModel.NewPassword" />
-                        <InputText type="password" autocomplete="new-password" autocapitalize="off" class="form-control" @bind-Value="_credentialsModel.NewPassword"/>
+                        <InputText type="password" autocomplete="new-password" autocapitalize="off" spellcheck="false" class="form-control" @bind-Value="_credentialsModel.NewPassword"/>
                         <ValidationMessage For="() => _credentialsModel.NewPassword" />
                     </div>
 
                     <div class="form-group">
                         <Name For="() => _credentialsModel.RepeatPassword" />
-                        <InputText type="password" autocomplete="new-password" autocapitalize="off" class="form-control" @bind-Value="_credentialsModel.RepeatPassword"/>
+                        <InputText type="password" autocomplete="new-password" autocapitalize="off" spellcheck="false" class="form-control" @bind-Value="_credentialsModel.RepeatPassword"/>
                         <ValidationMessage For="() => _credentialsModel.RepeatPassword" />
                     </div>
 

--- a/Ticky.Web/Components/Pages/UserSettings.razor
+++ b/Ticky.Web/Components/Pages/UserSettings.razor
@@ -150,20 +150,20 @@
                     {
                         <div class="form-group">
                             <Name For="() => _credentialsModel.OldPassword" />
-                            <InputText type="password" class="form-control" @bind-Value="_credentialsModel.OldPassword"/>
+                            <InputText type="password" autocomplete="current-password" class="form-control" @bind-Value="_credentialsModel.OldPassword"/>
                             <ValidationMessage For="() => _credentialsModel.OldPassword" />
                         </div>
                     }
 
                     <div class="form-group">
                         <Name For="() => _credentialsModel.NewPassword" />
-                        <InputText type="password" class="form-control" @bind-Value="_credentialsModel.NewPassword"/>
+                        <InputText type="password" autocomplete="new-password" class="form-control" @bind-Value="_credentialsModel.NewPassword"/>
                         <ValidationMessage For="() => _credentialsModel.NewPassword" />
                     </div>
 
                     <div class="form-group">
                         <Name For="() => _credentialsModel.RepeatPassword" />
-                        <InputText type="password" class="form-control" @bind-Value="_credentialsModel.RepeatPassword"/>
+                        <InputText type="password" autocomplete="new-password" class="form-control" @bind-Value="_credentialsModel.RepeatPassword"/>
                         <ValidationMessage For="() => _credentialsModel.RepeatPassword" />
                     </div>
 

--- a/Ticky.Web/Components/Pages/UserSettings.razor
+++ b/Ticky.Web/Components/Pages/UserSettings.razor
@@ -150,20 +150,20 @@
                     {
                         <div class="form-group">
                             <Name For="() => _credentialsModel.OldPassword" />
-                            <InputText type="password" autocomplete="current-password" class="form-control" @bind-Value="_credentialsModel.OldPassword"/>
+                            <InputText type="password" autocomplete="current-password" autocapitalize="off" class="form-control" @bind-Value="_credentialsModel.OldPassword"/>
                             <ValidationMessage For="() => _credentialsModel.OldPassword" />
                         </div>
                     }
 
                     <div class="form-group">
                         <Name For="() => _credentialsModel.NewPassword" />
-                        <InputText type="password" autocomplete="new-password" class="form-control" @bind-Value="_credentialsModel.NewPassword"/>
+                        <InputText type="password" autocomplete="new-password" autocapitalize="off" class="form-control" @bind-Value="_credentialsModel.NewPassword"/>
                         <ValidationMessage For="() => _credentialsModel.NewPassword" />
                     </div>
 
                     <div class="form-group">
                         <Name For="() => _credentialsModel.RepeatPassword" />
-                        <InputText type="password" autocomplete="new-password" class="form-control" @bind-Value="_credentialsModel.RepeatPassword"/>
+                        <InputText type="password" autocomplete="new-password" autocapitalize="off" class="form-control" @bind-Value="_credentialsModel.RepeatPassword"/>
                         <ValidationMessage For="() => _credentialsModel.RepeatPassword" />
                     </div>
 

--- a/Ticky.Web/Components/Pages/UserSettings.razor
+++ b/Ticky.Web/Components/Pages/UserSettings.razor
@@ -150,20 +150,20 @@
                     {
                         <div class="form-group">
                             <Name For="() => _credentialsModel.OldPassword" />
-                            <InputText class="form-control" @bind-Value="_credentialsModel.OldPassword"/>
+                            <InputText type="password" class="form-control" @bind-Value="_credentialsModel.OldPassword"/>
                             <ValidationMessage For="() => _credentialsModel.OldPassword" />
                         </div>
                     }
 
                     <div class="form-group">
                         <Name For="() => _credentialsModel.NewPassword" />
-                        <InputText class="form-control" @bind-Value="_credentialsModel.NewPassword"/>
+                        <InputText type="password" class="form-control" @bind-Value="_credentialsModel.NewPassword"/>
                         <ValidationMessage For="() => _credentialsModel.NewPassword" />
                     </div>
 
                     <div class="form-group">
                         <Name For="() => _credentialsModel.RepeatPassword" />
-                        <InputText class="form-control" @bind-Value="_credentialsModel.RepeatPassword"/>
+                        <InputText type="password" class="form-control" @bind-Value="_credentialsModel.RepeatPassword"/>
                         <ValidationMessage For="() => _credentialsModel.RepeatPassword" />
                     </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Password fields in User Settings (Old Password, New Password, Repeat Password) are now masked to hide characters while typing, improving privacy and reducing shoulder-surfing risk.
  * Autocomplete attributes added for current and new password fields to improve browser credential handling.
  * Typing behaviors adjusted (autocapitalize disabled, spellcheck off) to prevent unintended alterations while entering passwords.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->