### PR TITLE
fix: Action modal always fit on screen and adjust width/height if needed

### DIFF
--- a/Ticky.Web/Components/Dialogs/FilterCardsModal.razor
+++ b/Ticky.Web/Components/Dialogs/FilterCardsModal.razor
@@ -15,12 +15,12 @@
                 {
                     if (Model.ExpandAssignedUsersSection)
                     {
-                        <i class="fa fa-chevron-down edit-icon" @onclick="() => Model.ExpandAssignedUsersSection = false" title="Collapse"></i>
+                        <i class="fa fa-chevron-down edit-icon" @onclick="SwitchUserAssignedCollapse" title="Collapse"></i>
                     }
 
                     else
                     {
-                        <i class="fa fa-chevron-up edit-icon" @onclick="() => Model.ExpandAssignedUsersSection = true" title="Expand"></i>
+                        <i class="fa fa-chevron-up edit-icon" @onclick="SwitchUserAssignedCollapse" title="Expand"></i>
                     }
                 }
             </div>
@@ -49,12 +49,12 @@
                 {
                     if (Model.ExpandLabelsSection)
                     {
-                        <i class="fa fa-chevron-down edit-icon" @onclick="() => Model.ExpandLabelsSection = false" title="Collapse"></i>
+                        <i class="fa fa-chevron-down edit-icon" @onclick="SwitchLabelsCollapse" title="Collapse"></i>
                     }
 
                     else
                     {
-                        <i class="fa fa-chevron-up edit-icon" @onclick="() => Model.ExpandLabelsSection = true" title="Expand"></i>
+                        <i class="fa fa-chevron-up edit-icon" @onclick="SwitchLabelsCollapse" title="Expand"></i>
                     }
                 }
             </div>
@@ -121,6 +121,22 @@
             await InvokeAsync(async () => await SearchUpdated.InvokeAsync());
         };
         _debounceTimer.AutoReset = false;
+    }
+
+    private async Task SwitchUserAssignedCollapse()
+    {
+        Model.ExpandAssignedUsersSection = !Model.ExpandAssignedUsersSection;
+        StateHasChanged();
+        await Task.Delay(1);
+        await _modalRef!.OnResized();
+    }
+
+    private async Task SwitchLabelsCollapse()
+    {
+        Model.ExpandLabelsSection = !Model.ExpandLabelsSection;
+        StateHasChanged();
+        await Task.Delay(1);
+        await _modalRef!.OnResized();
     }
 
     private void OnSearchChanged(ChangeEventArgs e)

--- a/Ticky.Web/Components/Elements/ActionModal.razor
+++ b/Ticky.Web/Components/Elements/ActionModal.razor
@@ -1,6 +1,6 @@
-@inject IJSRuntime _js
+﻿@inject IJSRuntime _js
 
-<div @ref="_element" class="dropdown absolute top-0 left-0 z-20 hidden rounded-xs bg-modal shadow-2xl">
+<div @ref="_element" class="dropdown absolute top-0 left-0 z-20 hidden overflow-y-auto rounded-xs bg-modal shadow-2xl">
 	<section class="flex w-full flex-row items-center justify-center gap-10 px-2 py-3">
 		<label class="text-sm font-normal">@Title</label>
 		<i class="fa fa-xmark ml-auto cursor-pointer text-icon hover:text-icon-hover" @onclick="Close" title="Close"></i>
@@ -19,10 +19,14 @@
 	public required string Title { get; set; }
 
 	private ElementReference? _element;
+	private string? _elementId;
+	private ElementReference? _triggerElement;
 
 	public async void Open(string elementId)
 	{
-		await _js.InvokeVoidAsync("openDropDownOnElementId", _element, elementId);
+		_elementId = elementId;
+		await OnResized();
+
 		if (_element.HasValue)
 		{
 			await _js.InvokeVoidAsync("trapFocusInElement", _element);
@@ -31,11 +35,22 @@
 
 	public async void Open(ElementReference? triggerElement)
 	{
-		await _js.InvokeVoidAsync("openDropDownOnElementPosition", _element, triggerElement);
+		_triggerElement = triggerElement;
+		await OnResized();
+
 		if (_element.HasValue)
 		{
 			await _js.InvokeVoidAsync("trapFocusInElement", _element);
 		}
+	}
+
+	public async Task OnResized()
+	{
+		if(_triggerElement is not null)
+			await _js.InvokeVoidAsync("openDropDownOnElementPosition", _element, _triggerElement);
+
+		if (_elementId is not null)
+			await _js.InvokeVoidAsync("openDropDownOnElementId", _element, _elementId);
 	}
 
 	public async void Close() 

--- a/Ticky.Web/wwwroot/js/main.js
+++ b/Ticky.Web/wwwroot/js/main.js
@@ -14,13 +14,27 @@ function positionDropdown(dropdownElement, left, top, width = null) {
     const mostRightPoint = left + rect.width;
     const mostBottomPoint = top + rect.height;
 
-    if (mostRightPoint > window.innerWidth) {
-        dropdownElement.style.left = window.innerWidth - rect.width + 'px';
+    const availableWidth = document.documentElement.clientWidth - (OPEN_OFFSET * 2)
+    const availableHeight = document.documentElement.clientHeight - (OPEN_OFFSET * 2)
+
+    if (mostRightPoint > availableWidth) {
+        if(availableWidth > rect.width) {
+            dropdownElement.style.left = availableWidth - rect.width + 'px';
+        } else {
+            dropdownElement.style.left = OPEN_OFFSET + 'px';
+            dropdownElement.style.maxWidth = availableWidth + 'px';
+        }
     }
-    if (mostBottomPoint > window.innerHeight) {
-        dropdownElement.style.top = window.innerHeight - rect.height + 'px';
+    if (mostBottomPoint > availableHeight) {
+        if(availableHeight > rect.height) {
+            dropdownElement.style.top = availableHeight - rect.height + 'px';
+        } else {
+            dropdownElement.style.top = OPEN_OFFSET + 'px';
+            dropdownElement.style.maxHeight = availableHeight + 'px';
+        }
     }
 }
+
 let openDropdown = null
 let lastClosedX = null
 let lastClosedY = null


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Dropdown can now open relative to either a specific element or an element ID and repositions itself on resize.
  * Filter modal chevrons now toggle sections and auto-resize the modal.
* Bug Fixes
  * Improved dropdown positioning to stay within the viewport, preventing off-screen overflow.
* UI Improvements
  * Added vertical scrolling to the action modal to handle long content.
* Refactor
  * Centralized dropdown open/reposition logic.
  * Replaced inline state changes with toggle handlers for more reliable section expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->