### PR TITLE
feat: Added filter to exclude completed cards

### DIFF
--- a/Ticky.Base/Models/FilterCardsModel.cs
+++ b/Ticky.Base/Models/FilterCardsModel.cs
@@ -10,6 +10,8 @@ public class FilterCardsModel
 
     public bool IncludeUnassigned { get; set; }
 
+    public bool ExcludeCompleted { get; set; }
+
     public bool ExpandAssignedUsersSection { get; set; }
 
     public bool ExpandLabelsSection { get; set; }
@@ -19,7 +21,8 @@ public class FilterCardsModel
         return !string.IsNullOrWhiteSpace(Text)
             || AssignedUserIds.Count > 0
             || LabelIds.Count > 0
-            || IncludeUnassigned;
+            || IncludeUnassigned
+            || ExcludeCompleted;
     }
 
     public void ClearFilters()
@@ -28,5 +31,6 @@ public class FilterCardsModel
         AssignedUserIds.Clear();
         LabelIds.Clear();
         IncludeUnassigned = false;
+        ExcludeCompleted = false;
     }
 }

--- a/Ticky.Web/Components/Dialogs/FilterCardsModal.razor
+++ b/Ticky.Web/Components/Dialogs/FilterCardsModal.razor
@@ -12,7 +12,7 @@
                 <label>Completion</label>
             </div>
             <div class="flex flex-col gap-1">
-                <div class="flex w-72 cursor-pointer flex-row items-center gap-5 rounded px-2 py-1 text-sm transition-all ease-in-out select-none hover:bg-dropdown-option" @onclick="() => ToggleExcludeCompleted()">
+                <div class="flex w-72 cursor-pointer flex-row items-center gap-5 rounded px-2 py-1 text-sm transition-all ease-in-out select-none hover:bg-dropdown-option" @onclick="ToggleExcludeCompleted">
                     <span class="font-bold">Exclude completed cards</span>
                     <i class='fa fa-check icon ml-auto @(Model.ExcludeCompleted ? string.Empty : "opacity-0")'></i>
                 </div>
@@ -96,11 +96,6 @@
 </ActionModal>
 
 @code {
-    private async Task ToggleExcludeCompleted(ChangeEventArgs e)
-    {
-        Model.ExcludeCompleted = (bool)e.Value!;
-        await SearchUpdated.InvokeAsync();
-    }
     [Parameter]
     public EventCallback SearchUpdated { get; set; }
 

--- a/Ticky.Web/Components/Dialogs/FilterCardsModal.razor
+++ b/Ticky.Web/Components/Dialogs/FilterCardsModal.razor
@@ -9,6 +9,18 @@
 
         <div class="form-group">
             <div class="flex flex-row items-center gap-1 text-xs">
+                <label>Completion</label>
+            </div>
+            <div class="flex flex-col gap-1">
+                <div class="flex w-72 cursor-pointer flex-row items-center gap-5 rounded px-2 py-1 text-sm transition-all ease-in-out select-none hover:bg-dropdown-option" @onclick="() => ToggleExcludeCompleted()">
+                    <span class="font-bold">Exclude completed cards</span>
+                    <i class='fa fa-check icon ml-auto @(Model.ExcludeCompleted ? string.Empty : "opacity-0")'></i>
+                </div>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <div class="flex flex-row items-center gap-1 text-xs">
                 <label>Assigned users</label>
 
                 @if (BoardMembers.Count > 2)
@@ -84,6 +96,11 @@
 </ActionModal>
 
 @code {
+    private async Task ToggleExcludeCompleted(ChangeEventArgs e)
+    {
+        Model.ExcludeCompleted = (bool)e.Value!;
+        await SearchUpdated.InvokeAsync();
+    }
     [Parameter]
     public EventCallback SearchUpdated { get; set; }
 
@@ -165,6 +182,12 @@
     private async Task ToggleUnassignedFilter()
     {
         Model.IncludeUnassigned = !Model.IncludeUnassigned;
+        await SearchUpdated.InvokeAsync();
+    }
+
+    private async Task ToggleExcludeCompleted()
+    {
+        Model.ExcludeCompleted = !Model.ExcludeCompleted;
         await SearchUpdated.InvokeAsync();
     }
 

--- a/Ticky.Web/Components/Pages/BoardView.razor
+++ b/Ticky.Web/Components/Pages/BoardView.razor
@@ -629,9 +629,12 @@
             .Include(x => x.Subtasks)
             .Include(x => x.Labels)
             .Include(x => x.TimeRecords)
+            .Include(x => x.Column)
             .Where(x => columnIds.Contains(x.ColumnId))
             .Where(x => !x.SnoozedUntil.HasValue);
 
+        if (_filterModel.ExcludeCompleted)
+            queryableCards = queryableCards.Where(x => !x.Column.Finished);
 
         if(!string.IsNullOrWhiteSpace(_filterModel.Text))
         {

--- a/Ticky.Web/wwwroot/css/app.css
+++ b/Ticky.Web/wwwroot/css/app.css
@@ -276,14 +276,8 @@
   .static {
     position: static;
   }
-  .-top-1 {
-    top: calc(var(--spacing) * -1);
-  }
   .top-0 {
     top: calc(var(--spacing) * 0);
-  }
-  .-right-1 {
-    right: calc(var(--spacing) * -1);
   }
   .right-0 {
     right: calc(var(--spacing) * 0);
@@ -306,11 +300,14 @@
   .m-5 {
     margin: calc(var(--spacing) * 5);
   }
-  .mx-auto {
-    margin-inline: auto;
+  .my-2 {
+    margin-block: calc(var(--spacing) * 2);
   }
   .mt-1 {
     margin-top: calc(var(--spacing) * 1);
+  }
+  .mt-2 {
+    margin-top: calc(var(--spacing) * 2);
   }
   .mt-4 {
     margin-top: calc(var(--spacing) * 4);
@@ -323,6 +320,9 @@
   }
   .mr-auto {
     margin-right: auto;
+  }
+  .mb-1 {
+    margin-bottom: calc(var(--spacing) * 1);
   }
   .mb-2 {
     margin-bottom: calc(var(--spacing) * 2);
@@ -538,9 +538,6 @@
   }
   .min-w-80 {
     min-width: calc(var(--spacing) * 80);
-  }
-  .flex-1 {
-    flex: 1;
   }
   .flex-grow {
     flex-grow: 1;
@@ -808,9 +805,6 @@
   }
   .bg-column-limit-reached {
     background-color: var(--color-column-limit-reached);
-  }
-  .bg-dropdown-option {
-    background-color: var(--color-dropdown-option);
   }
   .bg-full-dropdown {
     background-color: var(--color-full-dropdown);
@@ -1084,9 +1078,6 @@
   }
   .text-orange-500 {
     color: var(--color-orange-500);
-  }
-  .text-pink-500 {
-    color: var(--color-pink-500);
   }
   .text-primary {
     color: var(--color-primary);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “Completion” section in the Filters modal with an “Exclude completed cards” toggle.
  - When enabled, cards in finished columns are hidden from the board.
  - This setting now counts toward “filters applied” and is cleared by “Clear Filters.”

- Style
  - Minor UI spacing adjustments with updated vertical margin utilities.
  - Some legacy styling options were removed; no functional impact expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->