### PR TITLE
fix: Make it easier to hit exit in modals on mobile devices

### DIFF
--- a/Ticky.Web/Components/Elements/ActionModal.razor
+++ b/Ticky.Web/Components/Elements/ActionModal.razor
@@ -1,9 +1,9 @@
-@inject IJSRuntime _js
+﻿@inject IJSRuntime _js
 
 <div @ref="_element" class="dropdown dropdown-animate absolute top-0 left-0 z-20 hidden overflow-y-auto rounded-xs bg-modal shadow-2xl">
 	<section class="flex w-full flex-row items-center justify-center gap-10 px-2 py-3">
 		<label class="text-sm font-normal">@Title</label>
-		<i class="fa fa-xmark ml-auto cursor-pointer text-icon hover:text-icon-hover" @onclick="Close" title="Close"></i>
+		<i class="fa fa-xmark card-button ml-auto" @onclick="Close" title="Close"></i>
 	</section>
 	<hr/>
 	<div class="px-2 py-2">

--- a/Ticky.Web/Components/Elements/Modal.razor
+++ b/Ticky.Web/Components/Elements/Modal.razor
@@ -6,7 +6,7 @@
 			{
 				<section class="flex flex-row items-center justify-between gap-10 px-7 py-3">
 					<h5>@Title</h5>
-					<i class="fa fa-xmark cursor-pointer text-icon hover:text-icon-hover" @onclick="Cancel" title="Close"></i>
+					<i class="fa fa-xmark card-button" @onclick="Cancel" title="Close"></i>
 				</section>
 				<section @ref=_childContent class="max-h-[80vh] overflow-y-auto px-7 py-5">@ChildContent</section>
 				@if (!DisableButtons)

--- a/Ticky.Web/Components/Pages/BoardView.razor
+++ b/Ticky.Web/Components/Pages/BoardView.razor
@@ -137,7 +137,7 @@
                                         } else {
                                             <div class="flex w-full flex-row items-center justify-between text-sm font-semibold">
                                                 <label>Create new card</label>
-                                                <i class="fa fa-xmark text-icon" @onclick="() => _adding = -1" @onclick:stopPropagation=true title="Cancel"></i>
+                                                <i class="fa fa-xmark card-button" @onclick="() => _adding = -1" @onclick:stopPropagation=true title="Cancel"></i>
                                             </div>
 
                                             <textarea class="h-16 w-full rounded-lg bg-card-bg p-2 text-start text-xs outline-1 outline-typing-outline" 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Standardized close/cancel icon styling across modals and the "Create new card" UI by switching to the unified card-button style for consistent appearance and spacing.
  - Removed legacy icon-specific styles to align with current design tokens.

- Chores
  - Minor formatting/encoding tweak in a component file with no behavioral impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->