### PR TITLE
feat: Use dev prefix/suffix in e-mails as well

### DIFF
--- a/Ticky.Internal/Services/EmailService.cs
+++ b/Ticky.Internal/Services/EmailService.cs
@@ -5,7 +5,7 @@ using Devity.NETCore.MailKit.Core;
 namespace Ticky.Internal.Services
 {
     public class EmailService(IEmailService emailService, ILogger<EmailService> logger)
-        : CommonMailService(emailService, $"{TITLE_KEY} | Ticky")
+        : CommonMailService(emailService, $"{TITLE_KEY} | {Constants.APP_NAME}")
     {
         private static readonly string VERIFY_EMAIL = Path.Combine(
             Constants.Emails.BASE_PATH,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email notification subjects now display your configured application name instead of the fixed “Ticky” label, ensuring accurate branding across all outgoing messages. This applies to password resets, invitations, alerts, and other system emails. No changes to user workflows; notifications continue to send as before, now with correct branding for multi-tenant or white-labeled setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->