### PR TITLE
fix: Incorrect stats visualization with 0 cards on the board

### DIFF
--- a/Ticky.Web/Components/Pages/BoardView.razor
+++ b/Ticky.Web/Components/Pages/BoardView.razor
@@ -192,7 +192,7 @@
                                         <label class="text-gray-500">@completedCards/@totalCards</label>
                                     </div>
                                     <div class="grid h-1 w-full rounded-lg">
-                                        <div class="z-10 w-24 rounded-lg bg-pink-500 transition-all" style="grid-row: 1; grid-column: 1; width: @(Math.Round((double) completedCards/totalCards*100))%;"></div>
+                                        <div class="z-10 w-24 rounded-lg bg-pink-500 transition-all" style="grid-row: 1; grid-column: 1; width: @(totalCards == 0 ? 0 : Math.Round((double) completedCards/totalCards*100))%;"></div>
                                         <div class="rounded-lg bg-pink-300" style="grid-row: 1; grid-column: 1;"></div>
                                     </div>
                                 </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Progress bar in Board view now handles empty boards safely, showing 0% when there are no cards, preventing divide-by-zero errors.
  * Improves stability and avoids visual glitches or incorrect percentages on new or cleared boards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->