### PR TITLE
fix: No longer break short words in card labels, only break if word too long for one entire line

### DIFF
--- a/Ticky.Web/Components/Elements/CardView.razor
+++ b/Ticky.Web/Components/Elements/CardView.razor
@@ -17,7 +17,7 @@
             <i class="fa fa-ellipsis card-button pr-1" title="Card options"></i>
         </Dropdown>
     </div>
-    <label class="cursor-pointer text-xs break-all">
+    <label class="cursor-pointer text-xs break-normal break-words">
         @Card.Name
     </label>
     <div class="flex flex-row items-center justify-between gap-3">

--- a/Ticky.Web/wwwroot/css/app.css
+++ b/Ticky.Web/wwwroot/css/app.css
@@ -1,4 +1,4 @@
-/*! tailwindcss v4.1.13 | MIT License | https://tailwindcss.com */
+/*! tailwindcss v4.1.14 | MIT License | https://tailwindcss.com */
 @layer properties;
 @layer theme, base, components, utilities;
 @layer theme {
@@ -492,9 +492,6 @@
   .w-100 {
     width: calc(var(--spacing) * 100);
   }
-  .w-\[90vw\] {
-    width: 90vw;
-  }
   .w-full {
     width: 100%;
   }
@@ -513,17 +510,11 @@
   .max-w-4xl {
     max-width: var(--container-4xl);
   }
-  .max-w-\[90vw\] {
-    max-width: 90vw;
-  }
   .max-w-\[1300px\] {
     max-width: 1300px;
   }
   .max-w-full {
     max-width: 100%;
-  }
-  .max-w-sm {
-    max-width: var(--container-sm);
   }
   .min-w-2 {
     min-width: calc(var(--spacing) * 2);
@@ -726,7 +717,7 @@
     border-radius: var(--radius-2xl);
   }
   .rounded-full {
-    border-radius: calc(infinity * 1px);
+    border-radius: calc(infinity * 1px) !important;
   }
   .rounded-lg {
     border-radius: var(--radius-lg);
@@ -1019,6 +1010,13 @@
   .font-semibold {
     --tw-font-weight: var(--font-weight-semibold);
     font-weight: var(--font-weight-semibold);
+  }
+  .break-normal {
+    overflow-wrap: normal;
+    word-break: normal;
+  }
+  .break-words {
+    overflow-wrap: break-word;
   }
   .break-all {
     word-break: break-all;
@@ -1370,21 +1368,6 @@
   .md\:max-w-3xl {
     @media (width >= 48rem) {
       max-width: var(--container-3xl);
-    }
-  }
-  .md\:max-w-lg {
-    @media (width >= 48rem) {
-      max-width: var(--container-lg);
-    }
-  }
-  .md\:max-w-sm {
-    @media (width >= 48rem) {
-      max-width: var(--container-sm);
-    }
-  }
-  .md\:max-w-xl {
-    @media (width >= 48rem) {
-      max-width: var(--container-xl);
     }
   }
   .md\:flex-row {
@@ -2081,7 +2064,7 @@ input[type="checkbox"].switch:checked:after {
   justify-content: center;
   gap: calc(var(--spacing) * 1);
   overflow: hidden;
-  border-radius: calc(infinity * 1px);
+  border-radius: calc(infinity * 1px) !important;
   background-color: var(--color-person-label-bg);
   padding: calc(var(--spacing) * 1);
   font-size: var(--text-xs);
@@ -2107,7 +2090,7 @@ input[type="checkbox"].switch:checked:after {
   justify-content: center;
   gap: calc(var(--spacing) * 2);
   overflow: hidden;
-  border-radius: calc(infinity * 1px);
+  border-radius: calc(infinity * 1px) !important;
   background-color: var(--color-person-label-bg);
   padding-inline: calc(var(--spacing) * 2);
   padding-block: calc(var(--spacing) * 1.5);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text wrapping for card titles to prevent awkward mid-word breaks.
  * Enhanced consistency of rounded UI elements.
  * Minor layout adjustments from utility cleanup; visuals may shift slightly on some screens.

* **Chores**
  * Upgraded Tailwind CSS to v4.1.14 for the latest fixes and utility updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->