### PR TITLE
feat: Automatically handle block/unlock based on card links setting

### DIFF
--- a/Ticky.Base/Constants.cs
+++ b/Ticky.Base/Constants.cs
@@ -96,11 +96,13 @@ namespace Ticky.Base
         public static readonly string ACCESS_UPLOADED_FILES_PATH = $"{ACCESS_UPLOADED_PATH}/files";
 
         public const string REPEATED_KEY = "is repeated by";
+        public const string BLOCKS_KEY = "blocks";
+        public const string BLOCKED_BY_KEY = "is blocked by";
 
         public static readonly Dictionary<string, string> LINK_TYPE_PAIRS =
             new()
             {
-                { "is blocked by", "blocks" },
+                { BLOCKED_BY_KEY, BLOCKS_KEY },
                 { "is tested by", "tests" },
                 { "relates to", "relates to" },
                 { REPEATED_KEY, "repeats" }

--- a/Ticky.Base/Entities/Board.cs
+++ b/Ticky.Base/Entities/Board.cs
@@ -19,6 +19,7 @@ public class Board : AbstractDbEntity, IDeletable
     public virtual List<LastVisit> LastVisits { get; set; } = [];
     public virtual List<Favorite> Favorites { get; set; } = [];
     public bool DisableSortingAnimations { get; set; }
+    public bool AutoBlockUnblock { get; set; }
 
     public bool VerifyAccess(User user) =>
         Memberships.Any(x => x.UserId.Equals(user.Id))

--- a/Ticky.Internal/Migrations/20251005101624_AutoBlock.Designer.cs
+++ b/Ticky.Internal/Migrations/20251005101624_AutoBlock.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Ticky.Internal.Data;
 
@@ -11,9 +12,11 @@ using Ticky.Internal.Data;
 namespace Ticky.Internal.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20251005101624_AutoBlock")]
+    partial class AutoBlock
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Ticky.Internal/Migrations/20251005101624_AutoBlock.cs
+++ b/Ticky.Internal/Migrations/20251005101624_AutoBlock.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Ticky.Internal.Migrations
+{
+    /// <inheritdoc />
+    public partial class AutoBlock : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "AutoBlockUnblock",
+                table: "Boards",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AutoBlockUnblock",
+                table: "Boards");
+        }
+    }
+}

--- a/Ticky.Web/Components/Dialogs/EditCardModal.razor
+++ b/Ticky.Web/Components/Dialogs/EditCardModal.razor
@@ -1017,6 +1017,11 @@
                 CardId = targetLink.CardOneId,
             });
 
+        if(targetLink.Category == Constants.BLOCKED_BY_KEY && targetLink.CardOne.Blocked)
+            targetLink.CardOne.Blocked = false;
+        else if(targetLink.Category == Constants.BLOCKS_KEY && targetLink.CardTwo.Blocked)
+            targetLink.CardTwo.Blocked = false;
+
         await db.SaveChangesAsync();
         await UpdateCard();
     }

--- a/Ticky.Web/Components/Dialogs/LinkCardsModal.razor
+++ b/Ticky.Web/Components/Dialogs/LinkCardsModal.razor
@@ -139,6 +139,11 @@
                 CardId = card.Id,
             });
 
+        if (_linkCardsModel.Text == Constants.BLOCKS_KEY && !targetCard.Column.Finished)
+            targetCard.Blocked = true;
+        else if (_linkCardsModel.Text == Constants.BLOCKED_BY_KEY && !card.Column.Finished)
+            card.Blocked = true;
+
         await db.SaveChangesAsync();
 
         _card = card;

--- a/Ticky.Web/Components/Elements/ColumnView.razor
+++ b/Ticky.Web/Components/Elements/ColumnView.razor
@@ -338,6 +338,18 @@
             IndexHelper.FixIndices(dbNewColumn.Cards);
 
             await db.SaveChangesAsync();
+
+            if(Board.AutoBlockUnblock)
+            {
+                await db.Cards
+                    .Include(x => x.LinkedIssuesOne)
+                    .Include(x => x.Column)
+                    .Where(x => x.LinkedIssuesOne
+                        .Any(y => y.CardTwoId == dbMovedCard.Id && y.Category == Constants.BLOCKED_BY_KEY)
+                    )
+                    .ExecuteUpdateAsync(x => x.SetProperty(y => y.Blocked, !dbNewColumn.Finished));
+            }
+
             await OnUpdate.InvokeAsync();
         }
         catch (Exception ex)

--- a/Ticky.Web/Components/Pages/BoardSettings.razor
+++ b/Ticky.Web/Components/Pages/BoardSettings.razor
@@ -29,7 +29,7 @@
     <section class="flex w-full max-w-4xl flex-grow flex-col gap-5 overflow-y-auto px-12 py-14">
         <header class="flex flex-row justify-between text-2xl font-bold">
             <div class="flex flex-col gap-3">
-                <a class="text-sm transition-colors link-muted hover:text-primary" href="/boards/@Id" title="Back to board">
+                <a class="link-muted text-sm transition-colors hover:text-primary" href="/boards/@Id" title="Back to board">
                     <i class="fa fa-chevron-left mr-2"></i>
                     Back to board
                 </a>
@@ -60,10 +60,18 @@
                     <div class="settings-item">
                         <div class="flex flex-col text-sm">
                             <label class="font-bold opacity-90">Disable sorting animations</label>
-                            <label class="w-4/5 max-w-2xl opacity-70">With many cards in a column, animating their movement can cause lag. If you're experiencing this or prefer a quicker snap to position, enable this option.'</label>
+                            <label class="w-4/5 max-w-2xl opacity-70">With many cards in a column, animating their movement can cause lag. If you're experiencing this or prefer a quicker snap to position, enable this option.</label>
                         </div>
 
                         <input type="checkbox" class="switch" checked=@_board.DisableSortingAnimations @onchange="(e) => OnSettingChanged(e, x => x.DisableSortingAnimations)">
+                    </div>
+                    <div class="settings-item">
+                        <div class="flex flex-col text-sm">
+                            <label class="font-bold opacity-90">Automatically mark cards as blocked/unblocked based on card links</label>
+                            <label class="w-4/5 max-w-2xl opacity-70">When a blocked card link is created, the blocked card will be marked as so in the UI automatically. Furthermore, when the blocking card is moved to a column marked as finished, the blocked card will be marked as unblocked (but the card link will remain).</label>
+                        </div>
+
+                        <input type="checkbox" class="switch" checked=@_board.AutoBlockUnblock @onchange="(e) => OnSettingChanged(e, x => x.AutoBlockUnblock)">
                     </div>
                 } else if (_tab == 2)
                 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - New Board setting: Automatically mark cards as blocked/unblocked based on card links.
  - Cards are auto-blocked when creating relevant links; linked cards update when a card moves to or from a finished column (when enabled).
  - Deleting a blocking link now clears the blocked state on affected cards.

- Bug Fixes
  - Ensures cards are unblocked when a blocking relationship is removed.

- Style
  - Minor copy and UI tweaks in Board Settings (punctuation fixes, class order).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->