### PR TITLE
fix: avoid JS interop errors during board teardown

### DIFF
--- a/Ticky.Web/Components/Pages/BoardView.razor
+++ b/Ticky.Web/Components/Pages/BoardView.razor
@@ -268,6 +268,10 @@
             var boardPreferences = await _protectedLocalStorage.GetAsync<BoardPreferencesModel>(Constants.StorageKeys.BoardPreferences);
             _preferences = (boardPreferences.Success ? boardPreferences.Value : new()) ?? new();
         }
+        catch (JSDisconnectedException)
+        {
+            _preferences = new();
+        }
         catch (CryptographicException)
         {
             _preferences = new();
@@ -277,6 +281,10 @@
         {
             var filterPreferences = await _protectedLocalStorage.GetAsync<FilterCardsModel>(FILTERS_SCOPED_KEY);
             _filterModel = (filterPreferences.Success ? filterPreferences.Value : new()) ?? new();
+        }
+        catch (JSDisconnectedException)
+        {
+            _filterModel = new();
         }
         catch(CryptographicException)
         {
@@ -330,6 +338,9 @@
             await _hubConnection.SendAsync(nameof(UpdateHub.SubscribeBoard), Id);
         } catch(Exception ex)
         {
+            if (_isDisposed)
+                return;
+
             _logger.LogError(ex, "Failed to start hub connection or subscribe to board {BoardId}", Id);
             MainLayout.RunNotification(new("Real-time updates unavailable. Please refresh the page.", NotificationType.Fail));
         }
@@ -496,6 +507,9 @@
         _board = board;
 
         await LoadCardsAsync();
+
+        if (_isDisposed)
+            return;
 
         await InvokeAsync(StateHasChanged);
     }

--- a/Ticky.Web/Components/Pages/BoardView.razor
+++ b/Ticky.Web/Components/Pages/BoardView.razor
@@ -8,6 +8,7 @@
 @inject ILogger<BoardView> _logger
 @inject IHttpContextAccessor _httpContextAccessor
 @inherits NotifiableBase
+@implements IAsyncDisposable
 
 @if (_board is not null)
 {
@@ -208,6 +209,7 @@
 
     private HubConnection? _hubConnection;
     private HashSet<string> _expandedSections = new();
+    private bool _isDisposed;
 
     protected override void OnParametersSet()
     {
@@ -340,6 +342,9 @@
         try
         {
             await _protectedLocalStorage.SetAsync(Constants.StorageKeys.BoardPreferences, _preferences);
+        }
+        catch (JSDisconnectedException)
+        {
         }
         catch (Exception ex)
         {
@@ -497,6 +502,9 @@
 
     private async Task LoadCardsAsync()
     {
+        if (_isDisposed)
+            return;
+
         ArgumentNullException.ThrowIfNull(_board);
 
         using var db = _dbContextFactory.CreateDbContext();
@@ -534,15 +542,38 @@
 
         _cards = await queryableCards.ToListAsync();
 
+        if (_isDisposed)
+            return;
+
         await InvokeAsync(StateHasChanged);
 
         try
         {
             await _protectedLocalStorage.SetAsync(FILTERS_SCOPED_KEY, _filterModel);
         }
+        catch (JSDisconnectedException)
+        {
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to save filter preferences.");
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _isDisposed = true;
+
+        if (_hubConnection is null)
+            return;
+
+        try
+        {
+            await _hubConnection.DisposeAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to dispose board hub connection.");
         }
     }
 
@@ -590,4 +621,3 @@
 
     private bool IsExpanded(string id) => _expandedSections.Contains(id);
 }
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved board page stability by stopping UI updates and real-time handling after the page is closed.
  * Prevented browser-disconnect errors from surfacing during preference loading/saving.
  * Cleaned up real-time hub subscriptions more reliably when leaving the board, reducing lingering background activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->